### PR TITLE
Allow for minor releases of doctrine-orm-module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "zendframework/zendframework": "2.*",
-        "doctrine/doctrine-orm-module": "0.7.*"
+        "doctrine/doctrine-orm-module": "~0.7"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Doctrine-orm-module is on 0.8 now
